### PR TITLE
Fix CORS and request Content-type checking

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/docker-existing-docker-compose
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
-    "name": "Existing Docker Compose (Extend)",
+    "name": "Phorza",
     // Update the 'dockerComposeFile' list if you have more compose files or use different names.
     // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
     "dockerComposeFile": [

--- a/src/Infrastructure/HTTP/Middleware/ErrorResponseMiddleware.php
+++ b/src/Infrastructure/HTTP/Middleware/ErrorResponseMiddleware.php
@@ -54,6 +54,9 @@ class ErrorResponseMiddleware
             $httpStatusCode = $errorCode;
         }
 
+        $this->app->response->setHeader('Access-Control-Allow-Origin', '*');
+        $this->app->response->setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, DELETE');
+        $this->app->response->setHeader('Access-Control-Allow-Headers', 'content-type');
         $this->app->response->setStatusCode($httpStatusCode)->setHeader('Content-Type', 'application/json')->sendHeaders();
         $this->app->response->setContent(json_encode($data))->send();
 

--- a/src/Infrastructure/HTTP/Middleware/NotFoundMiddleware.php
+++ b/src/Infrastructure/HTTP/Middleware/NotFoundMiddleware.php
@@ -12,6 +12,24 @@ final class NotFoundMiddleware implements MiddlewareInterface
 {
     public function beforeNotFound(Event $event, Micro $app): bool
     {
+        $app->response->setHeader('Access-Control-Allow-Origin', '*');
+        $app->response->setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, DELETE');
+        $app->response->setHeader('Access-Control-Allow-Headers', 'content-type');
+        if ($app->request->isOptions()) {
+            /** @var \Phalcon\Mvc\Router\Route $route */
+            foreach ($app->getRouter()->getRoutes() as $route) {
+                if ($route->getPattern() === '.*') {
+                    continue;
+                }
+                @preg_match($route->getCompiledPattern(), $app->request->getURI(), $matches);
+                if ($route->getCompiledPattern() === $app->request->getURI() || !empty($matches)) {
+                    $app->response->setStatusCode(200)->setHeader('Content-Type', 'application/json')->sendHeaders();
+                    $app->response->send();
+                    return false;
+                }
+            }
+        }
+
         $app->response->setStatusCode(404, 'Not Found')->setHeader('Content-Type', 'application/json')->sendHeaders();
         $app->response->setJsonContent([
             'code' => 404,

--- a/src/Infrastructure/HTTP/Middleware/RequestMiddleware.php
+++ b/src/Infrastructure/HTTP/Middleware/RequestMiddleware.php
@@ -38,7 +38,7 @@ class RequestMiddleware implements MiddlewareInterface
             exit;
         }
 
-        if ($app->request->getContentType() !== self::EXPECTED_CONTENT_TYPE) {
+        if (strpos($app->request->getContentType(), self::EXPECTED_CONTENT_TYPE) === false) {
             $app->response->setStatusCode(400, 'Bad Request')->setHeader('Content-Type', self::EXPECTED_CONTENT_TYPE)->sendHeaders();
             $app->response->setJsonContent(['errors' => [['status' => 400, 'message' => 'Invalid content-type']]])->send();
 


### PR DESCRIPTION
Fixing CORS errors when requesting API from another host.

Also fixing checking of request Content-type header when it includes `application/json` but not exactly equals it, like when it includes `vnd` or something similar.